### PR TITLE
add_mailer_timestamp

### DIFF
--- a/mailer.rb
+++ b/mailer.rb
@@ -5,6 +5,7 @@ require 'action_mailer'
 class Mailer < ActionMailer::Base
   def notification(to:, from:, subject:, worker_diff:)
     @worker_diff = worker_diff
+    @footer_timestamp = Time.now.strftime("%m/%d/%Y%l:%M%p %Z") # timestamp bottom of email to prevent trimming
     mail(to: to, from: from, subject: subject) do |format|
       format.text
       format.html

--- a/mailer/notification.html.erb
+++ b/mailer/notification.html.erb
@@ -3,3 +3,5 @@
 <span><%= @worker_diff %></span>
 
 <p>There appears to be a problem with one or more of your workers. Please investigate workers directly</p>
+
+<footer><%= @footer_timestamp %></footer>


### PR DESCRIPTION
This change adds a timestamp to the bottom of the email to prevent gmail
from trimming output and also show when the alert was generated on
system.