### PR TITLE
code_coverage_simplecov

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,6 @@ gem 'minitest-reporters'
 gem 'rubocop', '~> 0.60.0', require: false
 gem 'rufus-scheduler'
 gem 'shoulda-context'
+gem 'simplecov'
 gem 'vcr'
 gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
+    docile (1.3.1)
     dotenv (2.5.0)
     erubi (1.7.1)
     et-orbi (1.1.6)
@@ -94,6 +95,11 @@ GEM
       fugit (~> 1.1, >= 1.1.5)
     safe_yaml (1.0.4)
     shoulda-context (1.2.2)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -115,6 +121,7 @@ DEPENDENCIES
   rubocop (~> 0.60.0)
   rufus-scheduler
   shoulda-context
+  simplecov
   vcr
   webmock
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 require 'dotenv'
+require 'simplecov'
 
 # ENV vars are loaded from production config.env but prefixed with TEST_
 Dotenv.load('config.env')
@@ -9,3 +10,4 @@ require 'shoulda/context'
 require_relative 'vcr_config'
 
 Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
+SimpleCov.start


### PR DESCRIPTION
This change adds the simplecov gem and starts simplecov in the
test_helper. This will allow code coverage display on Code Climate.